### PR TITLE
Change shell script arguments to [ -n namelists_subdir ] exec_dir

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -35,7 +35,7 @@
       "hello": "test $DEVBOX_SHELL_ENABLED -eq 1 && echo \"Hello $USER\"",
       "setup": "bash $DEVBOX_PROJECT_ROOT/setup.sh $@",
       "jules": "bash $DEVBOX_PROJECT_ROOT/jules.sh $@",
-      "loobos": "bash $DEVBOX_PROJECT_ROOT/jules.sh -d $DEVBOX_PROJECT_ROOT/examples/loobos $DEVBOX_PROJECT_ROOT/examples/loobos/config",
+      "loobos": "bash $DEVBOX_PROJECT_ROOT/jules.sh -n config $DEVBOX_PROJECT_ROOT/examples/loobos",
     },
   },
 }


### PR DESCRIPTION
Single run, assuming the namelists are in a subdirectory of `exec_dir` called `config`,

```sh
devbox run jules -n config /path/to/exec_dir
```

Parallel run, assuming the namelists subdirectory is `config` for all experiments

```sh
devbox run jules -n config /path/to/exec_1 /path/to/exec_2 /path/to/exec_3 ...
```

Solves #16 